### PR TITLE
PR - Add CRUD endpoints to TodoApiController

### DIFF
--- a/Todo.Api/Controllers/TodoApiController.cs
+++ b/Todo.Api/Controllers/TodoApiController.cs
@@ -33,5 +33,58 @@ namespace Todo.Api.Controllers
             _logger.LogInformation("Retrieving all Todo items");
             return Ok(_todos);
         }
+
+        [HttpGet("{id}")]
+        public IActionResult Get(int id)
+        {
+            _logger.LogInformation($"Retrieving Todo item with id {id}");
+            var todo = _todos.FirstOrDefault(t => t.Id == id);
+            if (todo == null)
+            {
+                _logger.LogWarning($"Todo item with id {id} not found");
+                return NotFound();
+            }
+            return Ok(todo);
+        }
+
+        [HttpPost]
+        public IActionResult Post([FromBody] TodoModel todo)
+        {
+            _logger.LogInformation($"Creating new Todo item with title {todo.Title}");
+            todo.Id = _todos.Max(t => t.Id) + 1;
+
+            // o campo title não pode conter mais de 50 caracteres e não pode coter caracteres especiais
+            if (todo.Title.Length > 50 || !todo.Title.All(char.IsLetterOrDigit))
+            {
+                _logger.LogWarning("Title must have a maximum of 50 characters and cannot contain special characters");
+                return BadRequest();
+            }
+
+            _todos.Add(todo);
+            return CreatedAtAction(nameof(Get), new { id = todo.Id }, todo);
+        }
+
+        [HttpPut("{id}")]
+        public IActionResult Put(int id, [FromBody] TodoModel todo)
+        {
+            _logger.LogInformation($"Updating Todo item with id {id}");
+            var existingTodo = _todos.FirstOrDefault(t => t.Id == id);
+            if (existingTodo == null)
+            {
+                _logger.LogWarning($"Todo item with id {id} not found");
+                return NotFound();
+            }
+
+            // o campo title não pode conter mais de 50 caracteres e não pode coter caracteres especiais
+            if (existingTodo.Title.Length > 50 || !existingTodo.Title.All(char.IsLetterOrDigit))
+            {
+                _logger.LogWarning("Title must have a maximum of 50 characters and cannot contain special characters");
+                return BadRequest();
+            }
+
+            existingTodo.Title = todo.Title;
+            existingTodo.Completed = todo.Completed;
+            return NoContent();
+        }
     }
 }


### PR DESCRIPTION
Introduce new endpoints to the TodoApiController class:
- Add HttpGet endpoint to retrieve a Todo item by ID, with logging and NotFound response if item doesn't exist.
- Add HttpPost endpoint to create a new Todo item, with logging, ID assignment, title validation, and BadRequest response for validation failures. Returns CreatedAtAction response on success.
- Add HttpPut endpoint to update an existing Todo item by ID, with logging, NotFound response if item doesn't exist, title validation, and BadRequest response for validation failures. Returns NoContent response on success.